### PR TITLE
set compiled file as entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redux-action-reducer",
   "version": "1.0.0",
   "description": "Remove redux reducer boilerplate",
-  "main": "modules/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "rimraf dist && babel modules --out-dir dist",
     "test": "mocha --compilers js:babel-core/register"


### PR DESCRIPTION
I think it would be better if module's default entry point was the compiled file

For example, right now it gives error with webpack's babel-loader when it's set to exclude node_modules
