### PR TITLE
extendReducer method, tests and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,48 @@ const list = createReducer(
 
 If a reducer is not supplied, `payload` will be returned.
 
+##  extendReducer(reducer, ...actionHandlers)(defaultValue)
+
+Re-use an existing reducer and extend it with extra handlers using this pattern, for example:
+
+```js
+const reducer = [ 'ACTION1', (state, payload) => ({ ...state, [payload.id]: payload }) ]
+const reducer2 = extendReducer( reducer, 'ACTION2', [ 'ACTION3', () => ({}) ])
+```
+
+This comes in handy when a common pattern for a reducer can be re-used throughout the application, but sometimes requires extra cases handling.
+
+## Reducer Factories
+
+### What are reducer factories?
+
+In an application it is common for patterns to become reused many times over, in these cases some form of abstraction is useful.
+This library can be used to define a reducer factory that can be re-used throughout the code-base, here is an example.
+
+```js
+// queryReducerFactory.js
+export default ({ setAll, setField, resetAll }) => createReducer(
+  setAll,
+  [ ...setField, (state, payload) => ({ ...state, [payload.id]: payload.value }) ],
+  [ ...resetAll, () => ({}) ]
+)({})
+```
+This factory will create a reducer that can be combined wherever is useful in the state tree (using redux combineReducers), and is generated
+by passing in an object with 3 arrays of actions to perform the functions, setAll, setField and resetAll.
+
+This factory could be implemented as follows:
+
+```js
+import queryReducer from './queryReducerFactory'
+
+const reducer = queryReducer({
+  setAll: [ 'ACTION1', 'ACTION2' ],
+  setField: [ 'ACTION3' ],
+  resetAll: [ 'ACTION4', 'ACTION5' ]
+})
+```
+This gives full flexibility when defining which actions will be allowed to trigger the reducer behaviour.
+Extra cases can be handled in specific instantiations by using the `extendReducer` pattern (Above)
 
 ## Examples
 

--- a/modules/index.js
+++ b/modules/index.js
@@ -31,7 +31,7 @@ export const whenError = (reducer = payloadPassThrough) => (state, payload, erro
 export const whenSuccess = (reducer = payloadPassThrough) => (state, payload, error) =>
     error ? state : reducer(state, payload);
 
-export const extendReducer = (reducer, ...actionHandlers) => (defaultValue = null) => {
+export const extendReducer = (reducer) => (...actionHandlers) => (defaultValue = null) => {
   const extraReducer = createReducer(...actionHandlers)(defaultValue);
   return (state, action) =>
     extraReducer(reducer(state, action), action);

--- a/modules/index.js
+++ b/modules/index.js
@@ -30,3 +30,9 @@ export const whenError = (reducer = payloadPassThrough) => (state, payload, erro
 
 export const whenSuccess = (reducer = payloadPassThrough) => (state, payload, error) =>
     error ? state : reducer(state, payload);
+
+export const extendReducer = (reducer, ...actionHandlers) => (defaultValue = null) => {
+  const extraReducer = createReducer(...actionHandlers)(defaultValue);
+  return (state, action) =>
+    extraReducer(reducer(state, action), action);
+}

--- a/test/main.js
+++ b/test/main.js
@@ -70,7 +70,7 @@ describe('whenSuccess', () => {
 describe('extendReducer', () => {
   it('should reduce a single action with custom action reducers', () => {
       const reducer = createReducer('SEARCH')('');
-      const extendedReducer = extendReducer(reducer, [ 'RESET', () => '' ])('')
+      const extendedReducer = extendReducer(reducer)([ 'RESET', () => '' ])('')
       let state = extendedReducer('', { type: 'SEARCH', payload: 'abc' });
       expect(state).to.equal('abc');
       state = extendedReducer(state, { type: 'RESET' });
@@ -79,7 +79,7 @@ describe('extendReducer', () => {
 
   it('should extend a single action with another single action', () => {
       const reducer = createReducer('SEARCH')('');
-      const extendedReducer = extendReducer(reducer, 'SEARCH_AGAIN')('')
+      const extendedReducer = extendReducer(reducer)('SEARCH_AGAIN')('')
       let state = extendedReducer('', { type: 'SEARCH', payload: 'abc' });
       expect(state).to.equal('abc');
       state = extendedReducer(state, { type: 'SEARCH_AGAIN', payload: 'def' });
@@ -88,7 +88,7 @@ describe('extendReducer', () => {
 
   it('should reduce multiple actions with custom action reducers', () => {
       const reducer = createReducer([ 'SEARCH', 'SEARCH_AGAIN' ])('');
-      const extendedReducer = extendReducer(reducer, [ 'RESET', 'EMPTY', () => ''])('')
+      const extendedReducer = extendReducer(reducer)([ 'RESET', 'EMPTY', () => ''])('')
 
       let state = extendedReducer('', { type: 'SEARCH', payload: 'abc' });
       expect(state).to.equal('abc');

--- a/test/main.js
+++ b/test/main.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import createReducer, { whenError, whenSuccess } from '../modules';
+import createReducer, { whenError, whenSuccess, extendReducer } from '../modules';
 
 describe('createReducer', () => {
     it('should reduce a single action with identity function', () => {
@@ -14,7 +14,7 @@ describe('createReducer', () => {
         let state = reducer('', { type: 'SEARCH', payload: 'abc' });
         expect(state).to.equal('abc');
 
-        state = reducer(state, { type: 'SEARCH', payload: 'def' });
+        state = reducer(state, { type: 'SEARCH_AGAIN', payload: 'def' });
         expect(state).to.equal('def');
     });
 
@@ -65,4 +65,41 @@ describe('whenSuccess', () => {
         state = reducer(state, { type: 'RECEIVE_ITEMS', payload: [ 'item1', 'item2' ] });
         expect(state).to.eql([ 'item1', 'item2' ]);
     });
+});
+
+describe('extendReducer', () => {
+  it('should reduce a single action with custom action reducers', () => {
+      const reducer = createReducer('SEARCH')('');
+      const extendedReducer = extendReducer(reducer, [ 'RESET', () => '' ])('')
+      let state = extendedReducer('', { type: 'SEARCH', payload: 'abc' });
+      expect(state).to.equal('abc');
+      state = extendedReducer(state, { type: 'RESET' });
+      expect(state).to.equal('');
+  });
+
+  it('should extend a single action with another single action', () => {
+      const reducer = createReducer('SEARCH')('');
+      const extendedReducer = extendReducer(reducer, 'SEARCH_AGAIN')('')
+      let state = extendedReducer('', { type: 'SEARCH', payload: 'abc' });
+      expect(state).to.equal('abc');
+      state = extendedReducer(state, { type: 'SEARCH_AGAIN', payload: 'def' });
+      expect(state).to.equal('def');
+  });
+
+  it('should reduce multiple actions with custom action reducers', () => {
+      const reducer = createReducer([ 'SEARCH', 'SEARCH_AGAIN' ])('');
+      const extendedReducer = extendReducer(reducer, [ 'RESET', 'EMPTY', () => ''])('')
+
+      let state = extendedReducer('', { type: 'SEARCH', payload: 'abc' });
+      expect(state).to.equal('abc');
+
+      state = extendedReducer(state, { type: 'RESET' });
+      expect(state).to.equal('');
+
+      state = extendedReducer(state, { type: 'SEARCH_AGAIN', payload: 'def' });
+      expect(state).to.equal('def');
+
+      state = extendedReducer(state, { type: 'EMPTY' });
+      expect(state).to.equal('');
+  });
 });


### PR DESCRIPTION
extra functionality I've implemented and found very helpful when using createReducer to define reducer factories.
Extend reducer allows specialisation of common reducers that can be shared throughout the app