### PR TITLE
Update create reducer and add bind reducer

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -36,3 +36,18 @@ export const extendReducer = (reducer) => (...actionHandlers) => (defaultValue =
   return (state, action) =>
     extraReducer(reducer(state, action), action);
 }
+
+export const bindReducer = (actionOrActions, unboundReducer) => {
+  const actions = [].concat(actionOrActions)
+  actions.forEach((action) => {
+    if (typeof action !== 'string') {
+      throw new Error('Action type must be a string, received: ' + action);
+    }
+  })
+
+  if (typeof unboundReducer !== 'function') {
+    throw new Error('Reducer must be a function, received: ' + unboundReducer);
+  }
+
+  return createReducer([...actions, unboundReducer])
+}

--- a/modules/index.js
+++ b/modules/index.js
@@ -23,25 +23,15 @@ export const extendReducer = (reducer) => (defaultValue = null, ...boundReducers
 }
 
 export const bindReducer = (actionOrActions, unboundReducer = payloadPassThrough) => {
-  const actions = [].concat(actionOrActions)
-  actions.forEach((action) => {
-    if (typeof action !== 'string') {
-      throw new Error('Action type must be a string, received: ' + action);
+  const boundActions = [].concat(actionOrActions).map((actionType) => {
+    if (typeof actionType !== 'string') {
+      throw new Error('Action type must be a string, received: ' + actionType);
     }
+    return [actionType, unboundReducer]
   })
 
-  const boundActions = actions.reduce(
-      (acc, action) => {
-          acc[action] = unboundReducer
-          return acc;
-      },
-      {}
-  );
-
-  const boundActionsArray = Object.keys(boundActions).map(key => ([key, boundActions[key]]));
-
   return (defaultValue) => (state, { type, payload, error }) =>
-      boundActionsArray.reduce((accState, [actionType, reducer]) => {
+      boundActions.reduce((accState, [actionType, reducer]) => {
           if (type === actionType) {
               return reducer(accState, payload, error);
           }

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,10 +1,10 @@
 const payloadPassThrough = (state, payload) => payload;
 
 const createReducer = (defaultValue = null, ...boundReducerCreators) => {
-  const boundReducers = boundReducerCreators.map(creator => creator(defaultValue))
-  return (state, payload) => boundReducers.reduce((acc, boundReducer) => {
-      return boundReducer(acc, payload);
-  }, state)
+    const boundReducers = boundReducerCreators.map(creator => creator(defaultValue))
+    return (state, payload) => boundReducers.reduce((acc, boundReducer) => {
+        return boundReducer(acc, payload);
+    }, state)
 }
 
 
@@ -17,25 +17,25 @@ export const whenSuccess = (reducer = payloadPassThrough) => (state, payload, er
     error ? state : reducer(state, payload);
 
 export const extendReducer = (reducer) => (defaultValue = null, ...boundReducers) => {
-  const extraReducer = createReducer(defaultValue, ...boundReducers);
-  return (state, action) =>
-    extraReducer(reducer(state, action), action);
+    const extraReducer = createReducer(defaultValue, ...boundReducers);
+    return (state, action) =>
+        extraReducer(reducer(state, action), action);
 }
 
 export const bindReducer = (actionOrActions, unboundReducer = payloadPassThrough) => {
-  const boundActions = [].concat(actionOrActions).map((actionType) => {
-    if (typeof actionType !== 'string') {
-      throw new Error('Action type must be a string, received: ' + actionType);
-    }
-    return [actionType, unboundReducer]
-  })
+    const boundActions = [].concat(actionOrActions).map((actionType) => {
+        if (typeof actionType !== 'string') {
+          throw new Error('Action type must be a string, received: ' + actionType);
+        }
+        return [actionType, unboundReducer]
+    })
 
-  return (defaultValue) => (state, { type, payload, error }) =>
-      boundActions.reduce((accState, [actionType, reducer]) => {
-          if (type === actionType) {
-              return reducer(accState, payload, error);
-          }
+    return (defaultValue) => (state, { type, payload, error }) =>
+        boundActions.reduce((accState, [actionType, reducer]) => {
+            if (type === actionType) {
+                return reducer(accState, payload, error);
+            }
 
-          return accState;
-      }, state)
+            return accState;
+        }, state)
 }

--- a/modules/index.js
+++ b/modules/index.js
@@ -38,8 +38,10 @@ export const bindReducer = (actionOrActions, unboundReducer = payloadPassThrough
       {}
   );
 
+  const boundActionsArray = Object.keys(boundActions).map(key => ([key, boundActions[key]]));
+
   return (defaultValue) => (state, { type, payload, error }) =>
-      Object.entries(boundActions).reduce((accState, [actionType, reducer]) => {
+      boundActionsArray.reduce((accState, [actionType, reducer]) => {
           if (type === actionType) {
               return reducer(accState, payload, error);
           }

--- a/test/main.js
+++ b/test/main.js
@@ -1,5 +1,11 @@
 import { expect } from 'chai';
-import createReducer, { whenError, whenSuccess, extendReducer } from '../modules';
+
+import createReducer, {
+  whenError,
+  whenSuccess,
+  extendReducer,
+  bindReducer
+} from '../modules';
 
 describe('createReducer', () => {
     it('should reduce a single action with identity function', () => {
@@ -103,3 +109,34 @@ describe('extendReducer', () => {
       expect(state).to.equal('');
   });
 });
+
+
+describe('bindReducer', () => {
+  it('should bind a reducer to a single action', () => {
+    const boundReducer = bindReducer('RESET', () => 'reset');
+    const initialState = {};
+    const reducer = boundReducer(initialState);
+
+    let state = reducer(initialState, { type: 'RESET' });
+    expect(state).to.equal('reset');
+  })
+
+  it('should bind a reducer to multiple actions', () => {
+    const boundReducer = bindReducer(['RESET', 'REVERT'], () => 'reset');
+    const initialState = {};
+    const reducer = boundReducer(initialState);
+
+    expect(reducer(initialState, { type: 'RESET' })).to.equal('reset');
+    expect(reducer(initialState, { type: 'REVERT' })).to.equal('reset');
+  })
+
+  it('should throw if the action is not a string, and include the received action type', () => {
+    expect(() => bindReducer(undefined, () => {}))
+      .to.throw('Action type must be a string, received: undefined');
+  })
+
+  it('should throw if the reducer is not a function, and include the received object', () => {
+    expect(() => bindReducer('RESET', {}))
+      .to.throw('Reducer must be a function, received: [object Object]')
+  })
+})

--- a/test/main.js
+++ b/test/main.js
@@ -29,6 +29,17 @@ describe('createReducer', () => {
         state = reducer(state, { type: 'RESET', payload: 'item1' });
         expect(state).to.eql([]);
     });
+
+    it('chains multiple reducers together when they are bound to the same action', () => {
+      const initialState = { counter: 1 }
+      const reducer = createReducer(initialState,
+        bindReducer('INCREMENT', (state) => ({ counter: state.counter + 1 })),
+        bindReducer('INCREMENT', ({ counter }) => ({ counter, hasCounted: true }))
+      );
+
+      let state = reducer(initialState, { type: 'INCREMENT' })
+      expect(state).to.deep.equal({ counter: 2, hasCounted: true })
+    })
 });
 
 describe('whenError', () => {


### PR DESCRIPTION
# Why

When working with the existing API that `createReducer` exposes I've found the argument of an array of arrays that contain actions and the final element being a reducer, and then having to pass through the default value as another function call to be quite error prone from a developer perspective.

I also found the fact that each reducer that was bound to an action type would overwrite the previous action type's reducer - so this makes the reducers chainable and will pass the action through each one in turn.

# What

This PR adds a `bindReducer` function that takes a single action type or an array of action types as the first argument, and the reducer as a second argument. Since the API is fairly limited I've also added in some protections around passing in invalid action types (and kept the `payloadPassThrough` functionality if you don't provide a reducer).

It then also changes the API for `createReducer` to take the initial state as a first argument, and then allows you to pass in as many `bindReducer` calls as you want after that.

`extendReducer` has also had it's API updated to work with the new `createReducer`.

Thoughts/feedback appreciated 🙌 

**note**: I have not updated the README yet, figured a discussion/feedback first would be better.

## Examples

### Simple example

```javascript
const reducer = bindReducer('RESET', () => 'reset')('');

reducer('', { type: 'RESET' }); // returns state: 'reset'
```

### Multiple action types

```javascript
const reducer = bindReducer(['RESET', 'OTHER_RESET_ACTION'], () => 'reset')('');

// both of these return state: 'reset'
reducer('', { type: 'RESET' });
reducer('', { type: 'OTHER_RESET_ACTION' }); 
```

### Usage with `createReducer`

```javascript
const reducer = createReducer(
    '', 
    bindReducer('RESET', () => 'reset')
);

reducer('', { type: 'RESET' }); // returns state: 'reset'
```

### Chaining reducers bound to the same action type

```javascript
const initial = { counter: 0 }
const reducer = createReducer(
	initial,
	bindReducer('RESET', ({ counter }) => ({ counter: counter + 1 }))
	bindReducer('RESET', ({ counter }) => ({ counter: counter + 1 }))
)

reducer(initial, { type: 'RESET' }) // returns state: { counter: 2 }
```