### PR TITLE
Add warnings to create reducer

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -10,7 +10,7 @@ const handlePayloadPassThrough = (actionSpec) => {
   if (typeof maybeActionReducer === 'string') {
     return { actionTypes: actionSpec, actionReducer: payloadPassThrough };
   }
-  throw new Error('Reducer must either be a function or not present (payloadPassThrough)');
+  throw new Error('[redux-action-reducer] Arguments passed to createReducer must either contain a reducer function or none at all (payload pass-through).');
 }
 
 const createReducer = (...actionHandlers) => (defaultValue = null) => {
@@ -21,7 +21,7 @@ const createReducer = (...actionHandlers) => (defaultValue = null) => {
 
             actionTypes.forEach(actionType => {
               if (typeof actionType === 'undefined') {
-                throw new Error('actionTypes cannot be undefined')
+                throw new Error('[redux-action-reducer] An action type passed to createReducer is undefined')
               }
               acc[actionType] = actionReducer
             });

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,22 +1,23 @@
 const payloadPassThrough = (state, payload) => payload;
 
-const determineActionReducer = (maybeActionReducer, fallback) => {
+const handlePayloadPassThrough = (actionSpec) => {
+  const maybeActionReducer = actionSpec.slice(-1)[0];
+  const allButLast = actionSpec.slice(0, -1);
+
   if (typeof maybeActionReducer === 'function') {
-    return maybeActionReducer
+    return { actionTypes: allButLast, actionReducer: maybeActionReducer };
   }
   if (typeof maybeActionReducer === 'string') {
-    return fallback
+    return { actionTypes: actionSpec, actionReducer: payloadPassThrough };
   }
-  throw new Error('Reducer must either be a function or not present (payloadPassThrough)')
+  throw new Error('Reducer must either be a function or not present (payloadPassThrough)');
 }
 
 const createReducer = (...actionHandlers) => (defaultValue = null) => {
     const actions = actionHandlers.reduce(
         (acc, actionSpec) => {
             actionSpec = [].concat(actionSpec);
-            const last = actionSpec.slice(-1)[0];
-            const actionReducer = determineActionReducer(last, payloadPassThrough)
-            const actionTypes = actionReducer === payloadPassThrough ? actionSpec : actionSpec.slice(0, -1);
+            const { actionTypes, actionReducer } = handlePayloadPassThrough(actionSpec)
 
             actionTypes.forEach(actionType => {
               if (typeof actionType === 'undefined') {

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,14 +1,29 @@
 const payloadPassThrough = (state, payload) => payload;
 
+const determineActionReducer = (maybeActionReducer, fallback) => {
+  if (typeof maybeActionReducer === 'function') {
+    return maybeActionReducer
+  }
+  if (typeof maybeActionReducer === 'string') {
+    return fallback
+  }
+  throw new Error('Reducer must either be a function or not present (payloadPassThrough)')
+}
+
 const createReducer = (...actionHandlers) => (defaultValue = null) => {
     const actions = actionHandlers.reduce(
         (acc, actionSpec) => {
             actionSpec = [].concat(actionSpec);
             const last = actionSpec.slice(-1)[0];
-            const actionReducer = typeof last === 'function' ? last : payloadPassThrough;
+            const actionReducer = determineActionReducer(last, payloadPassThrough)
             const actionTypes = actionReducer === payloadPassThrough ? actionSpec : actionSpec.slice(0, -1);
 
-            actionTypes.forEach(actionType => acc[actionType] = actionReducer);
+            actionTypes.forEach(actionType => {
+              if (typeof actionType === 'undefined') {
+                throw new Error('actionTypes cannot be undefined')
+              }
+              acc[actionType] = actionReducer
+            });
             return acc;
         },
         {}

--- a/test/main.js
+++ b/test/main.js
@@ -37,6 +37,22 @@ describe('createReducer', () => {
         state = reducer(state, { type: 'RESET', payload: 'item1' });
         expect(state).to.eql([]);
     });
+
+    context('actionType of undefined is passed', () => {
+      it('should raise an error', () => {
+        const perform = () => createReducer([undefined, (state, payload) => state])(null)
+
+        expect(perform).to.throw('actionTypes cannot be undefined')
+      })
+    })
+
+    context('reducer is neither a function nor payloadPassThrough', () => {
+      it('shoudl raise an error', () => {
+        const perform = () => createReducer(['ACTION_TYPE', { reducer: 'invalid' }])(null)
+
+        expect(perform).to.throw('Reducer must either be a function or not present (payloadPassThrough)')
+      })
+    })
 });
 
 describe('whenError', () => {

--- a/test/main.js
+++ b/test/main.js
@@ -42,15 +42,15 @@ describe('createReducer', () => {
       it('should raise an error', () => {
         const perform = () => createReducer([undefined, (state, payload) => state])(null)
 
-        expect(perform).to.throw('actionTypes cannot be undefined')
+        expect(perform).to.throw('[redux-action-reducer] An action type passed to createReducer is undefined')
       })
     })
 
     context('reducer is neither a function nor payloadPassThrough', () => {
-      it('shoudl raise an error', () => {
+      it('should raise an error', () => {
         const perform = () => createReducer(['ACTION_TYPE', { reducer: 'invalid' }])(null)
 
-        expect(perform).to.throw('Reducer must either be a function or not present (payloadPassThrough)')
+        expect(perform).to.throw('[redux-action-reducer] Arguments passed to createReducer must either contain a reducer function or none at all (payload pass-through).')
       })
     })
 });


### PR DESCRIPTION
As mentioned in #4 - this PR adds adds some handling invalid usage of `createReducer`.

It also makes the reducer function detection branch more explicit now that we can also throw an error in some cases.