### PR TITLE
handle when the new state is undefined.

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -32,7 +32,11 @@ const createReducer = (...actionHandlers) => (defaultValue = null) => {
 
     return (state, { type, payload, error }) => {
         if (actions[type]) {
-            return actions[type](state, payload, error);
+            const newState = actions[type](state, payload, error);
+            if (typeof newState === 'undefined') {
+                console.error('[redux-action-reducer] action ' + type + ' returns undefined. Leaving state unchanged');
+            }
+            return typeof newState === 'undefined' ? state : newState;
         }
 
         return typeof state === 'undefined' ? defaultValue : state;


### PR DESCRIPTION
In the case where an action results in a new state that is undefined (e.g. passing an undefined payload to a payloadPassThrough), this causes redux to crash.
This PR logs an error in these cases and returns the previous state to avoid crashing redux.